### PR TITLE
2.1.0

### DIFF
--- a/BetterFarmAnimalVariety/Commands/BaseCommand.cs
+++ b/BetterFarmAnimalVariety/Commands/BaseCommand.cs
@@ -1,0 +1,36 @@
+﻿using BetterFarmAnimalVariety.Models;
+using StardewModdingAPI;
+using System.Collections.Generic;
+
+namespace BetterFarmAnimalVariety.Commands
+{
+    class BaseCommand
+    {
+
+        protected List<Command> Commands = new List<Command>();
+
+        protected readonly ModConfig Config;
+        protected readonly IModHelper Helper;
+        protected readonly IMonitor Monitor;
+
+        public BaseCommand(ModConfig config, IModHelper helper, IMonitor monitor)
+        {
+            this.Config = config;
+            this.Helper = helper;
+            this.Monitor = monitor;
+        }
+
+        public void SetUp()
+        {
+            foreach (Command command in this.Commands)
+            {
+                this.Helper.ConsoleCommands.Add(command.Name, command.Documentation, command.Callback);
+            }
+        }
+
+        protected void HandleUpdatedConfig()
+        {
+            this.Helper.WriteConfig<ModConfig>(this.Config);
+        }
+    }
+}

--- a/BetterFarmAnimalVariety/Commands/FarmAnimalsCommand.cs
+++ b/BetterFarmAnimalVariety/Commands/FarmAnimalsCommand.cs
@@ -1,0 +1,702 @@
+﻿using BetterFarmAnimalVariety.Models;
+using Paritee.StardewValleyAPI.Buildings;
+using Paritee.StardewValleyAPI.Buildings.AnimalHouses;
+using Paritee.StardewValleyAPI.FarmAnimals;
+using StardewModdingAPI;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BetterFarmAnimalVariety.Commands
+{
+    class FarmAnimalsCommand : BaseCommand
+    {
+        private const string ANIMAL_SHOP_AVAILABLE = "yes";
+        private const string ANIMAL_SHOP_UNAVAILABLE = "no";
+
+        public FarmAnimalsCommand(ModConfig config, IModHelper helper, IMonitor monitor) : base(config, helper, monitor)
+        {
+            this.Commands = new List<Command>()
+            {
+                new Command("bfav_fa", "List all farm animal commands.\nUsage: bfav_fa", this.ListCommands),
+                new Command("bfav_fa_list", "List the farm animal categories and types.\nUsage: bfav_fa_list", this.ListFarmAnimals),
+                new Command("bfav_fa_reset", "Reset the farm animals in config.json to vanilla default.\nUsage: bfav_fa_reset", this.Reset),
+                new Command("bfav_fa_addcategory", $"Add a unique category.\nUsage: bfav_fa_addcategory <category> <types> <buildings> <animalshop>\n- category: the unique animal category.\n- types: a comma separated string in quotes (ex \"White Cow,Brown Cow\").\n- buildings: a comma separated string in quotes (ex \"Barn,Deluxe Coop\").\n- animalshop: {FarmAnimalsCommand.ANIMAL_SHOP_AVAILABLE} or {FarmAnimalsCommand.ANIMAL_SHOP_UNAVAILABLE}.", this.AddCategory),
+                new Command("bfav_fa_removecategory", "Remove an existing category.\nUsage: bfav_fa_removecategory <category>\n- category: the unique animal category.", this.RemoveCategory),
+                new Command("bfav_fa_addtypes", "Add at least one animal type to a category.\nUsage: bfav_fa_addtypes <category> <types>\n- category: the unique animal category.\n- types: a comma separated string in quotes (ex \"White Cow,Brown Cow\").", this.AddTypes),
+                new Command("bfav_fa_removetypes", "Remove at least one animal type to a category.\nUsage: bfav_fa_removetypes <category> <types>\n- category: the unique animal category.\n- types: a comma separated string in quotes (ex \"White Cow,Brown Cow\").", this.RemoveTypes),
+                new Command("bfav_fa_setbuildings", "Set the category's buildings.\nUsage: bfav_fa_setbuildings <category> <buildings>\n- category: the unique animal category.\n- buildings: a comma separated string in quotes (ex \"Barn,Deluxe Coop\").", this.SetBuildings),
+                new Command("bfav_fa_setshop", $"Set the availability of this category in the animal shop.\nUsage: bfav_fa_setshop <category> <animalshop>\n- category: the unique animal category.\n- animalshop: {FarmAnimalsCommand.ANIMAL_SHOP_AVAILABLE} or {FarmAnimalsCommand.ANIMAL_SHOP_UNAVAILABLE}.", this.SetAnimalShop),
+                new Command("bfav_fa_setshopname", "Set the category's animal shop name.\nUsage: bfav_fa_setshopname <category> <name>\n- category: the unique animal category.\n- name: the displayed name.", this.SetAnimalShopName),
+                new Command("bfav_fa_setshopdescription", "Set the category's animal shop description.\nUsage: bfav_fa_setshopdescription <category> <description>\n- category: the unique animal category.\n- description: the description.", this.SetAnimalShopDescription),
+                new Command("bfav_fa_setshopprice", "Set the category's animal shop price.\nUsage: bfav_fa_setshopprice <category> <price>\n- category: the unique animal category.\n- price: the integer amount.", this.SetAnimalShopPrice),
+                new Command("bfav_fa_setshopicon", "Set the category's animal shop icon.\nUsage: bfav_fa_setshopicon <category> <filename>\n- category: the unique animal category.\n- filename: the name of the file (ex. filename.png).", this.SetAnimalShopIcon),
+            };
+        }
+
+        /// <summary>List all farm animal commands when the 'bfav_fa' command is invoked.</summary>
+        /// <param name="command">The name of the command invoked.</param>
+        /// <param name="args">The arguments received by the command. Each word after the command name is a separate argument.</param>
+        private void ListCommands(string command, string[] args)
+        {
+            foreach (Command cmd in this.Commands)
+            {
+                this.Helper.ConsoleCommands.Trigger($"help", new string[1] { cmd.Name });
+            }
+        }
+
+        /// <summary>List the farm animal categories and types when the 'bfav_fa_list' command is invoked.</summary>
+        /// <param name="command">The name of the command invoked.</param>
+        /// <param name="args">The arguments received by the command. Each word after the command name is a separate argument.</param>
+        private void ListFarmAnimals(string command, string[] args)
+        {
+            string output = "Listing BFAV farm animals\n";
+
+            foreach (KeyValuePair<string, ConfigFarmAnimal> entry in this.Config.FarmAnimals)
+            {
+                output += this.DescribeFarmAnimalCategory(entry);
+            }
+
+            this.Monitor.Log(output, LogLevel.Info);
+        }
+
+        /// <summary>Reset the farm animals in config.json to vanilla default when the 'bfav_fa_reset' command is invoked.</summary>
+        /// <param name="command">The name of the command invoked.</param>
+        /// <param name="args">The arguments received by the command. Each word after the command name is a separate argument.</param>
+        private void Reset(string command, string[] args)
+        {
+            ModConfig config = new ModConfig();
+
+            this.Config.FarmAnimals = config.FarmAnimals;
+
+            this.HandleUpdatedConfig();
+
+            this.Helper.ConsoleCommands.Trigger("bfav_fa_list", new string[] { });
+        }
+
+        /// <summary>Add a unique category when the 'bfav_fa_addcategory' command is invoked.</summary>
+        /// <param name="command">The name of the command invoked.</param>
+        /// <param name="args">The arguments received by the command. Each word after the command name is a separate argument.</param>
+        private void AddCategory(string command, string[] args)
+        {
+            if (args.Length > 4)
+            {
+                this.Monitor.Log($"use quotation marks (\") around your text if you are using spaces", LogLevel.Error);
+                return;
+            }
+
+            if (args.Length < 1)
+            {
+                this.Monitor.Log($"category is required", LogLevel.Error);
+                return;
+            }
+
+            string category = args[0].Trim();
+
+            if (this.Config.FarmAnimals.ContainsKey(category))
+            {
+                this.Monitor.Log($"{category} already exists in config.json", LogLevel.Error);
+                return;
+            }
+
+            if (args.Length < 2)
+            {
+                this.Monitor.Log($"type is required", LogLevel.Error);
+                return;
+            }
+
+            List<string> types = args[1].Split(',').Select(i => i.Trim()).ToList();
+            FarmAnimalsData farmAnimalsData = new FarmAnimalsData();
+
+            // Check if these new types are valid
+            foreach (string key in types)
+            {
+                if (!farmAnimalsData.Exists(key))
+                {
+                    this.Monitor.Log($"{key} does not exist in Data/FarmAnimals", LogLevel.Error);
+                    return;
+                }
+            }
+
+            string building = args.Length < 3 ? Barn.BARN : args[2].Trim();
+            List<string> buildings = new List<string>();
+
+            if (building.ToLower().Equals(Coop.COOP.ToLower()))
+            {
+                foreach (AnimalHouse.Size size in Enum.GetValues(typeof(Coop.Size)))
+                {
+                    buildings.Add(AnimalHouse.FormatBuilding(Coop.COOP, size));
+                }
+            }
+            else if (building.ToLower().Equals(Barn.BARN.ToLower()))
+            {
+                foreach (AnimalHouse.Size size in Enum.GetValues(typeof(Barn.Size)))
+                {
+                    buildings.Add(AnimalHouse.FormatBuilding(Barn.BARN, size));
+                }
+            }
+            else
+            {
+                buildings = building.Split(',').Select(i => i.Trim()).ToList();
+
+                BlueprintsData blueprintsData = new BlueprintsData();
+
+                // Check if these new types are valid
+                foreach (string key in buildings)
+                {
+                    if (!blueprintsData.Exists(key))
+                    {
+                        this.Monitor.Log($"{key} does not exist in Data/Blueprints", LogLevel.Error);
+                        return;
+                    }
+                }
+            }
+
+            string animalShop = args.Length < 4 ? FarmAnimalsCommand.ANIMAL_SHOP_UNAVAILABLE : args[3].Trim().ToLower();
+
+            if (!animalShop.Equals(FarmAnimalsCommand.ANIMAL_SHOP_AVAILABLE) && !animalShop.Equals(FarmAnimalsCommand.ANIMAL_SHOP_UNAVAILABLE))
+            {
+                this.Monitor.Log($"animalshop must be yes or no", LogLevel.Error);
+                return;
+            }
+
+            ConfigFarmAnimalAnimalShop configFarmAnimalAnimalShop;
+
+            try
+            {
+                configFarmAnimalAnimalShop = this.GetAnimalShopConfig(category, animalShop);
+            }
+            catch
+            {
+                // Messaging handled in function
+                return;
+            }
+
+            this.Config.FarmAnimals.Add(category, new ConfigFarmAnimal());
+
+            this.Config.FarmAnimals[category].Category = category;
+            this.Config.FarmAnimals[category].Types = types.Distinct().ToArray();
+            this.Config.FarmAnimals[category].Buildings = buildings.ToArray();
+            this.Config.FarmAnimals[category].AnimalShop = configFarmAnimalAnimalShop;
+
+            this.HandleUpdatedConfig();
+
+            string output = this.DescribeFarmAnimalCategory(new KeyValuePair<string, ConfigFarmAnimal>(category, this.Config.FarmAnimals[category]));
+
+            this.Monitor.Log(output, LogLevel.Info);
+        }
+
+        /// <summary>Remove an existing category when the 'bfav_fa_removecategory' command is invoked.</summary>
+        /// <param name="command">The name of the command invoked.</param>
+        /// <param name="args">The arguments received by the command. Each word after the command name is a separate argument.</param>
+        private void RemoveCategory(string command, string[] args)
+        {
+            if (args.Length > 1)
+            {
+                this.Monitor.Log($"use quotation marks (\") around your text if you are using spaces", LogLevel.Error);
+                return;
+            }
+
+            if (args.Length < 1)
+            {
+                this.Monitor.Log($"category is required", LogLevel.Error);
+                return;
+            }
+
+            string category = args[0];
+
+            if (!this.Config.FarmAnimals.ContainsKey(category))
+            {
+                this.Monitor.Log($"{category} is not a category in config.json", LogLevel.Error);
+                return;
+            }
+
+            this.Config.FarmAnimals.Remove(category);
+
+            this.HandleUpdatedConfig();
+
+            this.Helper.ConsoleCommands.Trigger("bfav_fa_list", new string[] { });
+        }
+
+        /// <summary>Add at least one animal type to a category when the 'bfav_fa_addtypes' command is invoked.</summary>
+        /// <param name="command">The name of the command invoked.</param>
+        /// <param name="args">The arguments received by the command. Each word after the command name is a separate argument.</param>ary>
+        private void AddTypes(string command, string[] args)
+        {
+            if (args.Length > 2)
+            {
+                this.Monitor.Log($"use quotation marks (\") around your text if you are using spaces", LogLevel.Error);
+                return;
+            }
+
+            if (args.Length < 1)
+            {
+                this.Monitor.Log($"category is required", LogLevel.Error);
+                return;
+            }
+
+            string category = args[0].Trim();
+
+            if (!this.Config.FarmAnimals.ContainsKey(category))
+            {
+                this.Monitor.Log($"{category} is not a category in config.json", LogLevel.Error);
+                return;
+            }
+
+            if (args.Length < 2)
+            {
+                this.Monitor.Log($"type is required", LogLevel.Error);
+                return;
+            }
+
+            List<string> types = new List<string>(this.Config.FarmAnimals[category].Types);
+            List<string> newTypes = args[1].Split(',').Select(i => i.Trim()).ToList();
+            FarmAnimalsData farmAnimalsData = new FarmAnimalsData();
+
+            // Check if these new types are valid
+            foreach (string newType in newTypes)
+            {
+                if (!farmAnimalsData.Exists(newType))
+                {
+                    this.Monitor.Log($"{newType} does not exist in Data/FarmAnimals", LogLevel.Error);
+                    return;
+                }
+            }
+
+            this.Config.FarmAnimals[category].Types = types.Concat(newTypes).Distinct().ToArray();
+
+            this.HandleUpdatedConfig();
+
+            string output = this.DescribeFarmAnimalCategory(new KeyValuePair<string, ConfigFarmAnimal>(category, this.Config.FarmAnimals[category]));
+
+            this.Monitor.Log(output, LogLevel.Info);
+        }
+
+        /// <summary>Remove at least one animal type to a category when the 'bfav_fa_removetypes' command is invoked.</summary>
+        /// <param name="command">The name of the command invoked.</param>
+        /// <param name="args">The arguments received by the command. Each word after the command name is a separate argument.</param>
+        private void RemoveTypes(string command, string[] args)
+        {
+            if (args.Length > 2)
+            {
+                this.Monitor.Log($"use quotation marks (\") around your text if you are using spaces", LogLevel.Error);
+                return;
+            }
+
+            if (args.Length < 1)
+            {
+                this.Monitor.Log($"category is required", LogLevel.Error);
+                return;
+            }
+
+            string category = args[0].Trim();
+
+            if (!this.Config.FarmAnimals.ContainsKey(category))
+            {
+                this.Monitor.Log($"{category} is not a category in config.json", LogLevel.Error);
+                return;
+            }
+
+            if (args.Length < 2)
+            {
+                this.Monitor.Log($"type is required", LogLevel.Error);
+                return;
+            }
+
+            List<string> types = new List<string>(this.Config.FarmAnimals[category].Types);
+            List<string> typesToBeRemoved = args[1].Split(',').Select(i => i.Trim()).ToList();
+            string[] newTypes = types.Except(typesToBeRemoved).ToArray();
+
+            if (newTypes.Length < 1)
+            {
+                this.Monitor.Log($"categories must contain at least one type", LogLevel.Error);
+                return;
+            }
+
+            this.Config.FarmAnimals[category].Types = newTypes;
+
+            this.HandleUpdatedConfig();
+
+            string output = this.DescribeFarmAnimalCategory(new KeyValuePair<string, ConfigFarmAnimal>(category, this.Config.FarmAnimals[category]));
+
+            this.Monitor.Log(output, LogLevel.Info);
+        }
+
+        /// <summary>Set the category's buildings when the 'bfav_fa_setbuildings' command is invoked.</summary>
+        /// <param name="command">The name of the command invoked.</param>
+        /// <param name="args">The arguments received by the command. Each word after the command name is a separate argument.</param>
+        private void SetBuildings(string command, string[] args)
+        {
+            if (args.Length > 2)
+            {
+                this.Monitor.Log($"use quotation marks (\") around your text if you are using spaces", LogLevel.Error);
+                return;
+            }
+
+            if (args.Length < 1)
+            {
+                this.Monitor.Log($"category is required", LogLevel.Error);
+                return;
+            }
+
+            string category = args[0].Trim();
+
+            if (!this.Config.FarmAnimals.ContainsKey(category))
+            {
+                this.Monitor.Log($"{category} does not exist in config.json", LogLevel.Error);
+                return;
+            }
+
+            if (args.Length < 2)
+            {
+                this.Monitor.Log($"buildings is required", LogLevel.Error);
+                return;
+            }
+
+            List<string> buildings = args[1].Split(',').Select(i => i.Trim()).ToList();
+
+            BlueprintsData blueprintsData = new BlueprintsData();
+
+            // Check if these new types are valid
+            foreach (string key in buildings)
+            {
+                if (!blueprintsData.Exists(key))
+                {
+                    this.Monitor.Log($"{key} does not exist in Data/Blueprints", LogLevel.Error);
+                    return;
+                }
+            }
+
+            this.Config.FarmAnimals[category].Buildings = buildings.ToArray();
+
+            this.HandleUpdatedConfig();
+
+            string output = this.DescribeFarmAnimalCategory(new KeyValuePair<string, ConfigFarmAnimal>(category, this.Config.FarmAnimals[category]));
+
+            this.Monitor.Log(output, LogLevel.Info);
+        }
+
+        /// <summary>Set the availability of this category in the animal shop 'bfav_fa_setshop' command is invoked.</summary>
+        /// <param name="command">The name of the command invoked.</param>
+        /// <param name="args">The arguments received by the command. Each word after the command name is a separate argument.</param>
+        private void SetAnimalShop(string command, string[] args)
+        {
+            if (args.Length < 1)
+            {
+                this.Monitor.Log($"category is required", LogLevel.Error);
+                return;
+            }
+
+            string category = args[0].Trim();
+
+            if (!this.Config.FarmAnimals.ContainsKey(category))
+            {
+                this.Monitor.Log($"{category} does not exist in config.json", LogLevel.Error);
+                return;
+            }
+
+            if (args.Length < 2)
+            {
+                this.Monitor.Log($"animalshop is required", LogLevel.Error);
+                return;
+            }
+
+            string animalShop = args[1].Trim().ToLower();
+
+            if (!animalShop.Equals(FarmAnimalsCommand.ANIMAL_SHOP_AVAILABLE) && !animalShop.Equals(FarmAnimalsCommand.ANIMAL_SHOP_UNAVAILABLE))
+            {
+                this.Monitor.Log($"animalshop must be yes or no", LogLevel.Error);
+                return;
+            }
+
+            if (animalShop.Equals(FarmAnimalsCommand.ANIMAL_SHOP_AVAILABLE) && this.Config.FarmAnimals[category].CanBePurchased())
+            {
+                this.Monitor.Log($"{category} is already available in the animal shop", LogLevel.Error);
+                return;
+            }
+            else if (animalShop.Equals(FarmAnimalsCommand.ANIMAL_SHOP_UNAVAILABLE) && !this.Config.FarmAnimals[category].CanBePurchased())
+            {
+                this.Monitor.Log($"{category} is already not available in the animal shop", LogLevel.Error);
+                return;
+            }
+
+            ConfigFarmAnimalAnimalShop configFarmAnimalAnimalShop;
+
+            try
+            {
+                configFarmAnimalAnimalShop = this.GetAnimalShopConfig(category, animalShop);
+            }
+            catch
+            {
+                // Messaging handled in function
+                return;
+            }
+
+            this.Config.FarmAnimals[category].AnimalShop = configFarmAnimalAnimalShop;
+
+            this.HandleUpdatedConfig();
+
+            string output = this.DescribeFarmAnimalCategory(new KeyValuePair<string, ConfigFarmAnimal>(category, this.Config.FarmAnimals[category]));
+
+            this.Monitor.Log(output, LogLevel.Info);
+        }
+
+        /// <summary>Set the category's animal shop name when the 'bfav_fa_setshopname' command is invoked.</summary>
+        /// <param name="command">The name of the command invoked.</param>
+        /// <param name="args">The arguments received by the command. Each word after the command name is a separate argument.</param>
+        private void SetAnimalShopName(string command, string[] args)
+        {
+            if (args.Length > 2)
+            {
+                this.Monitor.Log($"use quotation marks (\") around your text if you are using spaces", LogLevel.Error);
+                return;
+            }
+
+            if (args.Length < 1)
+            {
+                this.Monitor.Log($"category is required", LogLevel.Error);
+                return;
+            }
+
+            string category = args[0].Trim();
+
+            if (!this.Config.FarmAnimals.ContainsKey(category))
+            {
+                this.Monitor.Log($"{category} does not exist in config.json", LogLevel.Error);
+                return;
+            }
+
+            if (!this.Config.FarmAnimals[category].CanBePurchased())
+            {
+                this.Monitor.Log($"{category} is not available in the animal shop", LogLevel.Error);
+                return;
+            }
+
+            if (args.Length < 2)
+            {
+                this.Monitor.Log($"name is required", LogLevel.Error);
+                return;
+            }
+
+            this.Config.FarmAnimals[category].AnimalShop.Name = args[1].Trim();
+
+            this.HandleUpdatedConfig();
+
+            string output = this.DescribeFarmAnimalCategory(new KeyValuePair<string, ConfigFarmAnimal>(category, this.Config.FarmAnimals[category]));
+
+            this.Monitor.Log(output, LogLevel.Info);
+        }
+
+        /// <summary>Set the category's animal shop description when the 'bfav_fa_setshopdescription' command is invoked.</summary>
+        /// <param name="command">The name of the command invoked.</param>
+        /// <param name="args">The arguments received by the command. Each word after the command name is a separate argument.</param>
+        private void SetAnimalShopDescription(string command, string[] args)
+        {
+            if (args.Length > 2)
+            {
+                this.Monitor.Log($"use quotation marks (\") around your text if you are using spaces", LogLevel.Error);
+                return;
+            }
+
+            if (args.Length < 1)
+            {
+                this.Monitor.Log($"category is required", LogLevel.Error);
+                return;
+            }
+
+            string category = args[0].Trim();
+
+            if (!this.Config.FarmAnimals.ContainsKey(category))
+            {
+                this.Monitor.Log($"{category} does not exist in config.json", LogLevel.Error);
+                return;
+            }
+
+            if (!this.Config.FarmAnimals[category].CanBePurchased())
+            {
+                this.Monitor.Log($"{category} is not available in the animal shop", LogLevel.Error);
+                return;
+            }
+
+            if (args.Length < 2)
+            {
+                this.Monitor.Log($"description is required", LogLevel.Error);
+                return;
+            }
+
+            this.Config.FarmAnimals[category].AnimalShop.Description = args[1].Trim();
+
+            this.HandleUpdatedConfig();
+
+            string output = this.DescribeFarmAnimalCategory(new KeyValuePair<string, ConfigFarmAnimal>(category, this.Config.FarmAnimals[category]));
+
+            this.Monitor.Log(output, LogLevel.Info);
+        }
+
+        /// <summary>Set the category's animal shop price when the 'bfav_fa_setshopprice' command is invoked.</summary>
+        /// <param name="command">The name of the command invoked.</param>
+        /// <param name="args">The arguments received by the command. Each word after the command name is a separate argument.</param>
+        private void SetAnimalShopPrice(string command, string[] args)
+        {
+            if (args.Length > 2)
+            {
+                this.Monitor.Log($"use quotation marks (\") around your text if you are using spaces", LogLevel.Error);
+                return;
+            }
+
+            if (args.Length < 1)
+            {
+                this.Monitor.Log($"category is required", LogLevel.Error);
+                return;
+            }
+
+            string category = args[0].Trim();
+
+            if (!this.Config.FarmAnimals.ContainsKey(category))
+            {
+                this.Monitor.Log($"{category} does not exist in config.json", LogLevel.Error);
+                return;
+            }
+
+            if (!this.Config.FarmAnimals[category].CanBePurchased())
+            {
+                this.Monitor.Log($"{category} is not available in the animal shop", LogLevel.Error);
+                return;
+            }
+
+            if (args.Length < 2)
+            {
+                this.Monitor.Log($"price is required", LogLevel.Error);
+                return;
+            }
+
+
+            if (!int.TryParse(args[1], out int n))
+            {
+                this.Monitor.Log($"price must be a positive number", LogLevel.Error);
+                return;
+            }
+
+            if (n < 0)
+            {
+                this.Monitor.Log($"price must be a positive number", LogLevel.Error);
+                return;
+            }
+
+            this.Config.FarmAnimals[category].AnimalShop.Price = args[1].Trim();
+
+            this.HandleUpdatedConfig();
+
+            string output = this.DescribeFarmAnimalCategory(new KeyValuePair<string, ConfigFarmAnimal>(category, this.Config.FarmAnimals[category]));
+
+            this.Monitor.Log(output, LogLevel.Info);
+        }
+
+        /// <summary>Set the category's animal shop icon when the 'bfav_fa_setshopicon' command is invoked.</summary>
+        /// <param name="command">The name of the command invoked.</param>
+        /// <param name="args">The arguments received by the command. Each word after the command name is a separate argument.</param>
+        private void SetAnimalShopIcon(string command, string[] args)
+        {
+            if (args.Length > 2)
+            {
+                this.Monitor.Log($"use quotation marks (\") around your text if you are using spaces", LogLevel.Error);
+                return;
+            }
+
+            if (args.Length < 1)
+            {
+                this.Monitor.Log($"category is required", LogLevel.Error);
+                return;
+            }
+
+            string category = args[0].Trim();
+
+            if (!this.Config.FarmAnimals.ContainsKey(category))
+            {
+                this.Monitor.Log($"{category} does not exist in config.json", LogLevel.Error);
+                return;
+            }
+
+            if (!this.Config.FarmAnimals[category].CanBePurchased())
+            {
+                this.Monitor.Log($"{category} is not available in the animal shop", LogLevel.Error);
+                return;
+            }
+
+            if (args.Length < 2)
+            {
+                this.Monitor.Log($"icon is required", LogLevel.Error);
+                return;
+            }
+
+            string filename = Path.GetFileName(args[1]);
+            string pathToIcon = Path.Combine(Properties.Settings.Default.AssetsDirectory, filename);
+            string fullPathToIcon = Path.Combine(this.Helper.DirectoryPath, pathToIcon);
+
+            if (!File.Exists(fullPathToIcon))
+            {
+                this.Monitor.Log($"{fullPathToIcon} does not exist", LogLevel.Error);
+                return;
+            }
+
+            if (!Path.GetExtension(fullPathToIcon).ToLower().Equals(".png"))
+            {
+                this.Monitor.Log($"{filename} must be a .png", LogLevel.Error);
+                return;
+            }
+
+            this.Config.FarmAnimals[category].AnimalShop.Icon = args[1].Trim();
+
+            this.HandleUpdatedConfig();
+
+            string output = this.DescribeFarmAnimalCategory(new KeyValuePair<string, ConfigFarmAnimal>(category, this.Config.FarmAnimals[category]));
+
+            this.Monitor.Log(output, LogLevel.Info);
+        }
+
+        private string DescribeFarmAnimalCategory(KeyValuePair<string, ConfigFarmAnimal> entry)
+        {
+            string output = "";
+
+            output += $"{entry.Key}\n";
+            output += $"- Types: {String.Join(",", entry.Value.Types)}\n";
+            output += $"- Buildings: {String.Join(",", entry.Value.Buildings)}\n";
+            output += $"- AnimalShop:\n";
+            output += $"-- Name: {entry.Value.AnimalShop.Name}\n";
+            output += $"-- Description: {entry.Value.AnimalShop.Description}\n";
+            output += $"-- Price: {entry.Value.AnimalShop.Price}\n";
+            output += $"-- Icon: {entry.Value.AnimalShop.Icon}\n";
+
+            return output;
+        }
+
+        private ConfigFarmAnimalAnimalShop GetAnimalShopConfig(string category, string animalShop)
+        {
+            ConfigFarmAnimalAnimalShop configFarmAnimalAnimalShop = new ConfigFarmAnimalAnimalShop();
+
+            if (animalShop.Equals(FarmAnimalsCommand.ANIMAL_SHOP_UNAVAILABLE))
+            {
+                return configFarmAnimalAnimalShop;
+            }
+
+            configFarmAnimalAnimalShop.Category = category;
+            configFarmAnimalAnimalShop.Name = category;
+            configFarmAnimalAnimalShop.Description = configFarmAnimalAnimalShop.GetDescriptionPlaceholder();
+            configFarmAnimalAnimalShop.Price = ConfigFarmAnimalAnimalShop.PRICE_PLACEHOLDER;
+            configFarmAnimalAnimalShop.Icon = configFarmAnimalAnimalShop.GetDefaultIconPath();
+
+            string fullPathToIcon = Path.Combine(this.Helper.DirectoryPath, configFarmAnimalAnimalShop.Icon);
+
+            if (!File.Exists(fullPathToIcon))
+            {
+                this.Monitor.Log($"{fullPathToIcon} does not exist", LogLevel.Error);
+                throw new Exception();
+            }
+
+            return configFarmAnimalAnimalShop;
+        }
+    }
+}

--- a/BetterFarmAnimalVariety/ModApi.cs
+++ b/BetterFarmAnimalVariety/ModApi.cs
@@ -2,7 +2,10 @@
 using Paritee.StardewValleyAPI.Buildings.AnimalShop.FarmAnimals;
 using Paritee.StardewValleyAPI.FarmAnimals.Variations;
 using Paritee.StardewValleyAPI.Players;
+using Paritee.StardewValleyAPI.Players.Actions;
+using StardewModdingAPI;
 using StardewValley;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -10,48 +13,96 @@ namespace BetterFarmAnimalVariety
 {
     public class ModApi
     {
-        private ModConfig Config;
+        private readonly ModConfig Config;
+        private readonly ISemanticVersion ModVersion;
 
-        public ModApi(ModConfig config)
+        public ModApi(ModConfig config, ISemanticVersion modVersion)
         {
             this.Config = config;
+            this.ModVersion = modVersion;
         }
 
+        /// <param name="version">string</param>
         /// <returns>Returns Dictionary<string, string[]></returns>
-        public Dictionary<string, string[]> GetFarmAnimalsByCategory()
+        public Dictionary<string, string[]> GetFarmAnimalsByCategory(string version)
         {
+            if (!this.IsVersionSupported(version))
+            {
+                throw new NotSupportedException();
+            }
+
             return this.Config.FarmAnimals.ToDictionary(entry => entry.Key, entry => entry.Value.Types);
         }
 
+        /// <param name="version">string</param>
         /// <param name="player">Paritee.StardewValleyAPI.Players</param>
         /// <returns>Returns Paritee.StardewValleyAPI.FarmAnimals.Variations.Blue</returns>
-        public BlueVariation GetBlueFarmAnimals(Player player)
+        public BlueVariation GetBlueFarmAnimals(string version, Player player)
         {
+            if (!this.IsVersionSupported(version))
+            {
+                throw new NotSupportedException();
+            }
+
             BlueConfig blueConfig = new BlueConfig(player.HasSeenEvent(BlueVariation.EVENT_ID));
 
             return new BlueVariation(blueConfig);
         }
 
+        /// <param name="version">string</param>
         /// <param name="player">Paritee.StardewValleyAPI.Players</param>
         /// <returns>Returns Paritee.StardewValleyAPI.FarmAnimals.Variations.Void</returns>
-        public VoidVariation GetVoidFarmAnimals(Player player)
+        public VoidVariation GetVoidFarmAnimals(string version, Player player)
         {
+            if (!this.IsVersionSupported(version))
+            {
+                throw new NotSupportedException();
+            }
+
             VoidConfig voidConfig = new VoidConfig(this.Config.VoidFarmAnimalsInShop, player.HasCompletedQuest(VoidVariation.QUEST_ID));
 
             return new VoidVariation(voidConfig);
         }
 
+        /// <param name="version">string</param>
         /// <param name="farm">StardewValley.Farm</param>
         /// <param name="blueFarmAnimals">Paritee.StardewValleyAPI.FarmAnimals.Variations.BlueVariation</param>
         /// <param name="voidFarmAnimals">Paritee.StardewValleyAPI.FarmAnimals.Variations.VoidVariation</param>
         /// <returns>Returns Paritee.StardewValleyAPI.Buidlings.AnimalShop</returns>
-        public AnimalShop GetAnimalShop(Farm farm, BlueVariation blueFarmAnimals, VoidVariation voidFarmAnimals)
+        public AnimalShop GetAnimalShop(string version, Farm farm, BlueVariation blueFarmAnimals, VoidVariation voidFarmAnimals)
         {
+            if (!this.IsVersionSupported(version))
+            {
+                throw new NotSupportedException();
+            }
+
             List<FarmAnimalForPurchase> farmAnimalsForPurchase = this.Config.GetFarmAnimalsForPurchase(farm);
             StockConfig stockConfig = new StockConfig(farmAnimalsForPurchase, blueFarmAnimals, voidFarmAnimals);
             Stock stock = new Stock(stockConfig);
 
             return new AnimalShop(stock);
+        }
+
+        /// <param name="version">string</param>
+        /// <param name="player">Paritee.StardewValleyAPI.Players</param>
+        /// <param name="blueFarmAnimals">Paritee.StardewValleyAPI.FarmAnimals.Variations.BlueVariation</param>
+        /// <returns>Returns Paritee.StardewValleyAPI.Players.Actions.BreedFarmAnimal</returns>
+        public BreedFarmAnimal GetBreedFarmAnimal(string version, Player player, BlueVariation blueFarmAnimals)
+        {
+            if (!this.IsVersionSupported(version))
+            {
+                throw new NotSupportedException();
+            }
+
+            Dictionary<string, List<string>> farmAnimals = this.Config.GetFarmAnimalTypes();
+            BreedFarmAnimalConfig breedFarmAnimalConfig = new BreedFarmAnimalConfig(farmAnimals, blueFarmAnimals, this.Config.RandomizeNewbornFromCategory, this.Config.RandomizeHatchlingFromCategory, this.Config.IgnoreParentProduceCheck);
+            return new BreedFarmAnimal(player, breedFarmAnimalConfig);
+        }
+
+        private bool IsVersionSupported(string version)
+        {
+            // Must match the major version
+            return version == this.ModVersion.MajorVersion.ToString();
         }
     }
 }

--- a/BetterFarmAnimalVariety/ModCommand.cs
+++ b/BetterFarmAnimalVariety/ModCommand.cs
@@ -1,0 +1,30 @@
+﻿using BetterFarmAnimalVariety.Models;
+using Paritee.StardewValleyAPI.FarmAnimals;
+using StardewModdingAPI;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BetterFarmAnimalVariety
+{
+    public class ModCommand
+    {
+        private readonly ModConfig Config;
+        private readonly IModHelper Helper;
+        private readonly IMonitor Monitor;
+
+        public ModCommand(ModConfig config, IModHelper helper, IMonitor monitor)
+        {
+            this.Config = config;
+            this.Helper = helper;
+            this.Monitor = monitor;
+        }
+
+        public void SetUp()
+        {
+            (new Commands.FarmAnimalsCommand(this.Config, this.Helper, this.Monitor)).SetUp();
+        }
+    }
+}

--- a/BetterFarmAnimalVariety/ModConfig.cs
+++ b/BetterFarmAnimalVariety/ModConfig.cs
@@ -11,10 +11,15 @@ namespace BetterFarmAnimalVariety
 {
     public class ModConfig
     {
+        public string Format;
+        public bool IsEnabled;
         public VoidConfig.InShop VoidFarmAnimalsInShop;
+        public bool RandomizeNewbornFromCategory;
+        public bool RandomizeHatchlingFromCategory;
+        public bool IgnoreParentProduceCheck;
         public Dictionary<string, ConfigFarmAnimal> FarmAnimals;
 
-        private AppSettings AppSettings;
+        private readonly AppSettings AppSettings;
 
         public ModConfig()
         {
@@ -23,9 +28,19 @@ namespace BetterFarmAnimalVariety
               .ToDictionary(x => x.Name.ToString(), x => x.DefaultValue.ToString());
 
             this.AppSettings = new AppSettings(settings);
+            this.Format = null;
+            this.IsEnabled = true;
             this.VoidFarmAnimalsInShop = VoidConfig.InShop.Never;
+            this.RandomizeNewbornFromCategory = false;
+            this.RandomizeHatchlingFromCategory = false;
+            this.IgnoreParentProduceCheck = false;
 
             this.InitializeFarmAnimals();
+        }
+        
+        public bool IsValidFormat(string targetFormat)
+        {
+            return this.Format != null && this.Format.Equals(targetFormat);
         }
 
         private List<string> GetFarmAnimalGroups()
@@ -33,16 +48,16 @@ namespace BetterFarmAnimalVariety
             return this.FarmAnimals.Keys.ToList<string>();
         }
 
-        public List<string> GetFarmAnimalTypes()
+        public Dictionary<string, List<string>> GetFarmAnimalTypes()
         {
-            List<string> types = new List<string>();
+            Dictionary<string, List<string>> farmAnimals = new Dictionary<string, List<string>>();
 
-            foreach (KeyValuePair<string, ConfigFarmAnimal> Entry in this.FarmAnimals)
+            foreach (KeyValuePair<string, ConfigFarmAnimal> entry in this.FarmAnimals)
             {
-                types = types.Concat(Entry.Value.GetTypes()).ToList<string>();
+                farmAnimals.Add(entry.Key, new List<string>(entry.Value.Types));
             }
 
-            return types.ToList<string>();
+            return farmAnimals;
         }
 
         public List<string> GetFarmAnimalTypes(string category)

--- a/BetterFarmAnimalVariety/ModEntry.cs
+++ b/BetterFarmAnimalVariety/ModEntry.cs
@@ -23,6 +23,7 @@ namespace BetterFarmAnimalVariety
     public class ModEntry : Mod
     {
         public ModConfig Config;
+        public ModCommand Command;
 
         public Player Player;
         public BlueVariation BlueFarmAnimals;
@@ -39,7 +40,27 @@ namespace BetterFarmAnimalVariety
         public override void Entry(IModHelper helper)
         {
             // Config
-            this.Config = this.LoadConfig();
+            try
+            {
+                this.Config = this.LoadConfig();
+            }
+            catch(FormatException)
+            {
+                this.Monitor.Log($"Your config.json format is invalid and BFAV has shut down. You are running BFAV v{this.ModManifest.Version.ToString()} which requires a config.json format of {this.ModManifest.Version.MajorVersion.ToString()}.", LogLevel.Alert);
+                return;
+            }
+
+            if (!this.Config.IsEnabled)
+            {
+                this.Monitor.Log($"BFAV is disabled. To enable, set IsEnabled to true in config.json.", LogLevel.Debug);
+                return;
+            }
+
+            // Harmony
+            this.ApplyHarmonyPatches();
+
+            // Commands
+            this.ApplyConsoleCommands();
 
             // Asset Editors
             this.Helper.Content.AssetEditors.Add(new AnimalBirthEditor(this));
@@ -50,8 +71,6 @@ namespace BetterFarmAnimalVariety
             this.Helper.Events.Display.RenderedActiveMenu += this.OnRenderedActiveMenu;
             this.Helper.Events.Input.ButtonPressed += this.OnButtonPressed;
             this.Helper.Events.Display.MenuChanged += this.OnMenuChanged;
-
-            this.ApplyHarmonyPatches();
         }
 
         private void ApplyHarmonyPatches()
@@ -73,15 +92,36 @@ namespace BetterFarmAnimalVariety
             harmony.Patch(targetMethod, prefixMethod, null);
         }
 
+        private void ApplyConsoleCommands()
+        {
+            this.Command = new ModCommand(this.Config, this.Helper, this.Monitor);
+
+            this.Command.SetUp();
+        }
+
         public override object GetApi()
         {
-            return new ModApi(this.Config);
+            return new ModApi(this.Config, this.ModManifest.Version);
         }
 
         private ModConfig LoadConfig()
         {
-            // Load up the config
+            // Load the config
             ModConfig config = this.Helper.ReadConfig<ModConfig>();
+
+            string targetFormat = this.ModManifest.Version.MajorVersion.ToString();
+
+            // Do this outside of the constructor so that we can use the ModManifest helper
+            if (config.Format == null)
+            {
+                config.Format = targetFormat;
+
+                this.Helper.WriteConfig<ModConfig>(config);
+            }
+            else if (!config.IsValidFormat(targetFormat))
+            {
+                throw new FormatException();
+            }
 
             config.InitializeFarmAnimals();
 
@@ -123,8 +163,8 @@ namespace BetterFarmAnimalVariety
 
             if (namingMenu.GetType() == typeof(StardewValley.Menus.NamingMenu))
             {
-                List<string> loadedTypes = this.Config.GetFarmAnimalTypes();
-                BreedFarmAnimalConfig breedFarmAnimalConfig = new BreedFarmAnimalConfig(loadedTypes, this.BlueFarmAnimals);
+                Dictionary<string, List<string>> farmAnimals = this.Config.GetFarmAnimalTypes();
+                BreedFarmAnimalConfig breedFarmAnimalConfig = new BreedFarmAnimalConfig(farmAnimals, this.BlueFarmAnimals, this.Config.RandomizeNewbornFromCategory, this.Config.RandomizeHatchlingFromCategory, this.Config.IgnoreParentProduceCheck);
                 BreedFarmAnimal breedFarmAnimal = new BreedFarmAnimal(this.Player, breedFarmAnimalConfig);
 
                 NameFarmAnimalMenu nameFarmAnimalMenu = new NameFarmAnimalMenu(namingMenu, breedFarmAnimal);

--- a/BetterFarmAnimalVariety/Models/Command.cs
+++ b/BetterFarmAnimalVariety/Models/Command.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BetterFarmAnimalVariety.Models
+{
+    class Command
+    {
+        public string Name;
+        public string Documentation;
+        public Action<string, string[]> Callback;
+
+        public Command(string name, string documentation, Action<string, string[]> callback)
+        {
+            this.Name = name;
+            this.Documentation = documentation;
+            this.Callback = callback;
+        }
+    }
+}

--- a/BetterFarmAnimalVariety/Models/ConfigFarmAnimalAnimalShop.cs
+++ b/BetterFarmAnimalVariety/Models/ConfigFarmAnimalAnimalShop.cs
@@ -7,6 +7,7 @@ namespace BetterFarmAnimalVariety.Models
     public class ConfigFarmAnimalAnimalShop
     {
         public const string NOT_APPLICABLE = "null";
+        public const string PRICE_PLACEHOLDER = "1000";
 
         public string DefaultNameStringID;
         public string DefaultDescriptionStringID;
@@ -113,7 +114,7 @@ namespace BetterFarmAnimalVariety.Models
                     return null;
                 }
 
-                return Path.Combine(Properties.Settings.Default.AssetsDirectory, "animal_shop_" + this.Category.ToLower() + ".png");
+                return this.GetDefaultIconPath();
             }
             set
             {
@@ -165,6 +166,16 @@ namespace BetterFarmAnimalVariety.Models
         public string DetermineDescriptionStringKey()
         {
             return "PurchaseAnimalsMenu.cs." + this.DefaultDescriptionStringID;
+        }
+
+        public string GetDescriptionPlaceholder()
+        {
+            return Game1.content.LoadString("Strings\\StringsFromCSFiles:BluePrint.cs.1");
+        }
+
+        public string GetDefaultIconPath()
+        {
+            return Path.Combine(Properties.Settings.Default.AssetsDirectory, "animal_shop_" + this.Category.ToLower() + ".png");
         }
     }
 }

--- a/BetterFarmAnimalVariety/Paritee's Better Farm Animal Variety.csproj
+++ b/BetterFarmAnimalVariety/Paritee's Better Farm Animal Variety.csproj
@@ -39,8 +39,8 @@
       <HintPath>..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Paritee.StardewValleyAPI, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Paritee.StardewValleyAPI.2.0.0\lib\net452\Paritee.StardewValleyAPI.dll</HintPath>
+    <Reference Include="Paritee.StardewValleyAPI, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Paritee.StardewValleyAPI.2.1.0\lib\net452\Paritee.StardewValleyAPI.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
@@ -54,9 +54,13 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Commands\BaseCommand.cs" />
+    <Compile Include="Commands\FarmAnimalsCommand.cs" />
     <Compile Include="ModApi.cs" />
+    <Compile Include="ModCommand.cs" />
     <Compile Include="Models\AppSettings.cs" />
     <Compile Include="Models\AppSetting.cs" />
+    <Compile Include="Models\Command.cs" />
     <Compile Include="Models\ConfigFarmAnimal.cs" />
     <Compile Include="Editors\AnimalBirthEditor.cs" />
     <Compile Include="ModConfig.cs" />
@@ -91,6 +95,9 @@
     <Content Include="assets\*">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Exceptions\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />

--- a/BetterFarmAnimalVariety/manifest.json
+++ b/BetterFarmAnimalVariety/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
    "Name": "Paritee's Better Farm Animal Variety",
    "Author": "Paritee",
-   "Version": "2.0.0",
+   "Version": "2.1.0",
    "Description": "Customize the types and species of farm animals you can raise without needing to replace the default farm animal types",
    "UniqueID": "Paritee.BetterFarmAnimalVariety",
    "EntryDll": "BetterFarmAnimalVariety.dll",

--- a/BetterFarmAnimalVariety/packages.config
+++ b/BetterFarmAnimalVariety/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Lib.Harmony" version="1.2.0.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net452" />
-  <package id="Paritee.StardewValleyAPI" version="2.0.0" targetFramework="net452" />
+  <package id="Paritee.StardewValleyAPI" version="2.1.0" targetFramework="net452" />
   <package id="Pathoschild.Stardew.ModBuildConfig" version="2.2.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
- Added commands for managing the BFAV config.json file from SMAPI without having to manually update the JSON
- Added more configurations for determining whether or not a newborn/hatchling can be a type within its category and not just from the parent/producer. If IgnoreParentProduceCheck is off, this means that a white egg could hatch into a Brown Chicken. If randomize is est to true, non-producing animals will be included like bulls and roosters
- Added format and enable flag to config.json
- Added versioning and GetBreedFarmAnimal to the API